### PR TITLE
transport.ts: Remove incorrect interpretation of empty incoming packet.

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -177,11 +177,6 @@ export default class NodeUsbTransport extends EventEmitter implements ITransport
         }
         throw e;
       }
-      if (headerBuffer.length === 0) {
-        this.emit('TRANSPORT_RESET');
-        this.logger.warn('Hlink transport reset message recieved during read');
-        return;
-      }
     } while (headerBuffer.length === 0);
 
     if (headerBuffer.length < MessagePacket.HEADER_SIZES.HDR_SIZE) {

--- a/tests/transport.spec.ts
+++ b/tests/transport.spec.ts
@@ -169,18 +169,6 @@ describe('UsbTransport', () => {
       expect(readStub.callCount).to.be.equal(1);
       expect(transport.running).to.equal(true);
     });
-
-    describe('on hlink reset sequence', () => {
-      it('should emit TRANSPORT_RESET if it got a empty header', async () => {
-        readStub.returns(new Promise(resolve => {
-          setTimeout(() => resolve(Buffer.alloc(0)), 10);
-        }));
-        const resetPromise = new Promise(resolve => transport.on('TRANSPORT_RESET', resolve));
-        transport.initEventLoop();
-        const message = await resetPromise;
-        expect(message).to.be.undefined;
-      });
-    });
   });
 
   describe('#on', () => {


### PR DESCRIPTION
Empty incoming packet is to be expected when received HLink message ends
with a USB packet whose length equals wMaxPacketLength.

There is no HLink reset semantics defined for packets traveling from
device to host.