### PR TITLE
fix(Transport): Fixing event emitter bug on transport #receivemsg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@huddly/device-api-usb",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huddly/device-api-usb",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Huddly SDK device api which uses node-usb wrapper responsible for handling the transport layer of the communication and discovering the physical device/camera",
   "keywords": [
     "API",

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -240,15 +240,20 @@ export default class NodeUsbTransport extends EventEmitter implements ITransport
           clearTimeout(timer);
         }
       }, timeout);
-      this.once(msg, res => {
-        clearTimeout(timer);
-        resolve(res);
-      });
 
-      this.once('ERROR', error => {
+      const messageHandler = res => {
         clearTimeout(timer);
+        this.removeListener('ERROR', errorHandler);
+        resolve(res);
+      };
+      const errorHandler = error => {
+        clearTimeout(timer);
+        this.removeListener(msg, messageHandler);
         reject(error);
-      });
+      };
+
+      this.once(msg, messageHandler);
+      this.once('ERROR', errorHandler);
     });
   }
 


### PR DESCRIPTION
On the Transport.ts class the #receiveMessage class was creating infinite on('ERROR') listeners
without ever unsubscrubing to them. This happens when the actual message is emitted from the camera,
in that case the promise used to clear the timeout and resolve, without unsubscribing to the Error
listeners. So, everytime a message was received, an error event listener was left out.