### PR TITLE
fix(download-binaries.js) Delete prebuilds dir when downloading binaries

### DIFF
--- a/scripts/release-current-platform.js
+++ b/scripts/release-current-platform.js
@@ -49,6 +49,14 @@ for (const runtime in builtVersions) {
   targets.push(`--target=${runtime}@${version}`);
 }
 
+if (!fs.existsSync(destDir)) {
+  fs.mkdirSync(destDir);
+}
+
+if (!fs.existsSync(destScripts)) {
+  fs.mkdirSync(destScripts);
+}
+
 /**
  * Convenience function for copying the contents of a
  * directory into another directory
@@ -134,9 +142,6 @@ function prepareBinaries() {
  * @returns Promise
  */
 function prepareDistPackage() {
-  fs.mkdirSync(destDir);
-  fs.mkdirSync(destScripts);
-
   delete pkg.devDependencies;
   delete pkg.optionalDependencies;
   delete pkg.bundledDependencies;
@@ -201,9 +206,9 @@ function sendFiles() {
   return Promise.all(promises);
 }
 
-prepareBinaries()
+createManifestFile(destDir, false, sha)
+.then(prepareBinaries)
 .then(prepareDistPackage)
-.then(() => createManifestFile(destDir, false, sha))
 .then(createTarball)
 .then(sendFiles)
 .catch((e) => {


### PR DESCRIPTION
Always delete the prebuilds folder inside the `lib` directory when downloading binaries of device-api-usb. This is to avoid having any cached prebuilds on the host machine, we make sure that we start with a clean workspace, i.e. deleting the old binaries and downloading the new ones.