### PR TITLE
fix(Device discovery): Fix device discovery when serial number contains space

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -79,7 +79,7 @@ export default class DeviceDiscoveryManager implements IDeviceDiscovery {
         `Filtering the devices for the following serial number: ${serialNumber}`,
         'Device API USB Manager'
       );
-      return devices.find(d => d.serialNumber.indexOf(serialNumber) >= 0);
+      return devices.find(d => d.serialNumber.replace(' ', '_').indexOf(serialNumber) >= 0);
     } else if (devices.length > 0) {
       if (devices.length !== 1) {
         this.logger.warn(


### PR DESCRIPTION
When IQ doesn't have proper factory settings, the serial number is 'Not found'. It seems that the uvc
discovery gets this as 'Not_found', and then no device is matched. This commit works around this
issue.