### PR TITLE
Allow listDevices to update list when serial is 'unknown'

### DIFF
--- a/cpp/usb_worker.cpp
+++ b/cpp/usb_worker.cpp
@@ -91,11 +91,6 @@ static std::string maybe_get_string(libusb::Device & dev, uint8_t string, int re
         auto err = std::get<libusb::Error>(maybe_devh);
         switch (err.number) {
         case LIBUSB_ERROR_ACCESS:
-            if (retry <= 0) {
-                return err.get_message();
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
-            return maybe_get_string(dev, string, retry - 1);
         case LIBUSB_ERROR_NOT_SUPPORTED:
             break;
         case LIBUSB_ERROR_NOT_FOUND:
@@ -195,7 +190,7 @@ struct Context {
                 devices.insert(std::make_pair(cookie.cookie, idev));
             }
             else {
-                if (serial.empty()){
+                if (serial.empty() || (serial == "Unknown serial")){
                     serial = maybe_get_string(dev, descr.iSerialNumber);
                 }
                 ret_devices.emplace_back(Usb_cookie(found), descr.idVendor, descr.idProduct, serial, location);

--- a/src/bulkusbdevice.ts
+++ b/src/bulkusbdevice.ts
@@ -85,7 +85,7 @@ export class BulkUsbSingleton {
         const newDevices = [];
         const ret = newList.map(newDevice => {
           const oldDevice = this._previousDevices.find(x => x.equals(newDevice));
-          if (oldDevice) {
+          if (oldDevice && oldDevice.serialNumber != 'Unknown serial') {
             return oldDevice;
           }
           newDevices.push(newDevice);

--- a/tests/bulkusbdeviceSingleton.spec.ts
+++ b/tests/bulkusbdeviceSingleton.spec.ts
@@ -52,6 +52,40 @@ describe('BulkUsbDeviceSingleton', () => {
       expect(devices[1].serialNumber).to.be.equal('serial-2');
       expect(devices[2].serialNumber).to.be.equal('serial-1');
     });
+
+    it('should update serial if current is unknown', async () => {
+      dummyCpp.listDevices.yields([
+        {
+          vid: 0x21,
+          pid: 0x21,
+          serial: 'Unknown serial',
+          cookie: 1,
+        },
+        {
+          vid: 0x21,
+          pid: 0x21,
+          serial: 'serial-2',
+          cookie: 2,
+        }
+      ]);
+      await bulkusbSingleton.listDevices();
+      dummyCpp.listDevices.yields([
+        {
+          vid: 0x21,
+          pid: 0x21,
+          serial: 'serial-2',
+          cookie: 2
+        },
+        {
+          vid: 0x21,
+          pid: 0x21,
+          serial: 'New serial',
+          cookie: 1
+        },
+      ]);
+      const updatedDevices = await bulkusbSingleton.listDevices();
+      expect(updatedDevices[1].serialNumber).to.be.equal('New serial');
+    });
   });
 
   describe('#onAttach', () => {


### PR DESCRIPTION
When listing devices the function _listDevices checks if the new list
(newList) has devices already listed in previousList. The problem is
that an "old" device might lack a serial, but since comparison only
looks at the cookie, that device won't be updated with a valid serial,
even if one is present in the new list.
    
So when creating the list, make sure that "unknown serial"s are updated.