### PR TITLE
Improve logging when usb descriptor read iSerialNumber fails

### DIFF
--- a/cpp/usb_worker.cpp
+++ b/cpp/usb_worker.cpp
@@ -109,10 +109,14 @@ static std::string maybe_get_string(libusb::Device & dev, uint8_t usbDescriptorI
     auto devh = std::get<libusb::Open_device>(std::move(maybe_devh));
     auto maybe_string = devh.get_string_descriptor(usbDescriptorIndex);
     if (std::holds_alternative<libusb::Error>(maybe_string)) {
-
         auto err = std::get<libusb::Error>(maybe_string);
-        std::cerr << "Error getting string descriptor: " << err.get_message() << " | Requested DescriptorIdx: " << unsigned(usbDescriptorIndex) << std::endl;
-        return err.get_message();
+        if (retry == 0 && usbDescriptorIndex == 0) {
+            // Report error when we have used up all the retry steps
+            std::cerr << "Error getting string descriptor: " << err.get_message() << " | Requested DescriptorIdx: " << unsigned(usbDescriptorIndex) << std::endl;
+            return err.get_message();
+        }
+
+        return "";
     }
     return std::get<std::string>(std::move(maybe_string));
 }


### PR DESCRIPTION
Suppress the error message during the first attempts at reading the serial number from usb descriptor. Do print the message if all attempts at reading the serial number fail. Here is an example of how master looks like before this change (Note the `LIBUSB_ERROR_INVALID_PARAM`):

```
07:01:09  + ./clijs info
07:01:12  Error getting string descriptor: LIBUSB_ERROR_INVALID_PARAM
07:01:12  Error getting string descriptor: LIBUSB_ERROR_INVALID_PARAM
07:01:12  {
07:01:12   "id": "IOService:/IOResources/AppleUSBHostResourcesTypeCBPC/AppleUSBLegacyRoot/AppleUSBXHCI@14000000/Huddly IQ@14800000",
07:01:12   "serialNumber": "B40K00585",
07:01:12   "vendorId": 11225,
07:01:12   "productId": 33,
07:01:12   "version": "1.4.23-113295",
07:01:12   "softwareVersion": "HuddlyIQ-1.4.23-113295",
07:01:12   "uptime": 5.58,
07:01:12   "pathName": "IOService:/IOResources/AppleUSBHostResourcesTypeCBPC/AppleUSBLegacyRoot/AppleUSBXHCI@14000000/Huddly IQ@14800000"
07:01:12  }
```

And after the change:

```
14:45:36  + ./clijs info
14:45:40  {
14:45:40   "id": "IOService:/IOResources/AppleUSBHostResources/AppleUSBLegacyRoot/AppleUSBXHCI@14000000/Huddly IQ@14800000",
14:45:40   "serialNumber": "40H00053",
14:45:40   "vendorId": 11225,
14:45:40   "productId": 33,
14:45:40   "version": "1.4.23-113295",
14:45:40   "softwareVersion": "HuddlyIQ-1.4.23-113295",
14:45:40   "uptime": 7.02,
14:45:40   "pathName": "IOService:/IOResources/AppleUSBHostResources/AppleUSBLegacyRoot/AppleUSBXHCI@14000000/Huddly IQ@14800000"
14:45:40  }
```