### PR TITLE
fix(transport.ts): Use wMaxPacketSize for read

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -116,7 +116,12 @@ export default class NodeUsbTransport extends EventEmitter implements ITransport
   initEventLoop(): void {
     if (!this.isPollingActive) {
       Logger.debug('Starting event loop!', this.className);
-      this.inEndpoint.startPoll(1, this.MAX_PACKET_SIZE);
+
+      if (this.inEndpoint.descriptor?.wMaxPacketSize == undefined) {
+        throw new Error('InEndpoint does not contain information about max packet size!');
+      }
+
+      this.inEndpoint.startPoll(1, this.inEndpoint.descriptor.wMaxPacketSize);
       this.startListen();
       this.isPollingActive = true;
     }


### PR DESCRIPTION
In case the inEndpoint descriptor information contains data defining the maximum allowed packet size, then we should use that one instead of our own. In case such information is missing then we should throw an error because this is an unexpected behavior